### PR TITLE
Convert IP to string before comparing to avoid unicode issues.

### DIFF
--- a/aws_ec2_assign_elastic_ip/__init__.py
+++ b/aws_ec2_assign_elastic_ip/__init__.py
@@ -160,7 +160,7 @@ def _is_valid(address):
     for conf_ip in args.valid_ips.split(','):
         try:
             for ip in IPNetwork(conf_ip):
-                if ip == address:
+                if str(ip) == str(address):
                     return True
 
         except AddrFormatError as err:


### PR DESCRIPTION
This matching fails on Centos 6.5 due to the address variable beeing passed in as unicode.

Added a fix which works for me.

```
               logger.debug( '"{0}"({1}) == "{2}({3})"'.format( ip, type(ip), address, type(address) ) )
               if str(ip) == str(address):
                   return True
```

Will result in:

`"54.77.xx.xx"(<class 'netaddr.ip.IPAddress'>) == "54.77.xx.xx(<type 'unicode'>)"`
