### PR TITLE
configparser support for both python2.7 and 3.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Supported platforms
 
 The `aws-ec2-assign-elastic-ip` should work fine on Linux, Mac OS X and Microsoft Windows. Please submit an issue if you have any issues with any of the platforms.
 
-We currently support Python 2.6 and 2.7. Python 3 support is missing as [`boto`](https://github.com/boto/boto) only supports the 2.x series at the moment.
+We currently support Python 2.6, 2.7 and 3.X
 
 Required IAM permissions
 ------------------------

--- a/aws_ec2_assign_elastic_ip/command_line_options.py
+++ b/aws_ec2_assign_elastic_ip/command_line_options.py
@@ -1,7 +1,10 @@
 """ Command line parser """
 import argparse
 import sys
-from ConfigParser import SafeConfigParser
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    from configparser import SafeConfigParser
 from argparse import RawTextHelpFormatter
 
 if sys.platform in ['win32', 'cygwin']:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 """ Setup script for PyPI """
 import os
 from setuptools import setup
-from ConfigParser import SafeConfigParser
+try:
+    from ConfigParser import SafeConfigParser
+except ImportError:
+    from configparser import SafeConfigParser
 
 settings = SafeConfigParser()
 settings.read(os.path.realpath('aws_ec2_assign_elastic_ip/settings.conf'))

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     scripts=['aws-ec2-assign-elastic-ip'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=['boto >= 2.29.1', 'netaddr >= 0.7.12'],
+    install_requires=['boto >= 2.36.0', 'netaddr >= 0.7.12'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
in Python3.X ConfigParser was renamed to configparser for PEP8 compatibility.