### PR TITLE
Add --replace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ The script is configured using command line options. You can provide your AWS cr
                             - 58.0.0.0/8
                             - 123.213.0.0/16,58.0.0.0/8,195.234.023.0
                             - 195.234.234.23,195.234.234.24
+      --replace
+			    If the instance is alredy assigned an IP not in
+  			    valid-ips then replace it
 
 The `--valid-ips` option require the public IPs in a comma separated sequence. E.g. `56.123.56.123,56.123.56.124,56.123.56.125`.
 
@@ -58,15 +61,17 @@ Required IAM permissions
 
 **Community contribution much appreciated on this!**
 
-We have been using the following IAM policys to be able to list and associate Elastic IPs. This can probably be narrowed down abit. It allows EC2 read-only (from the IAM wizard) and `ec2:AssociateAddress` permissions:
+We have been using the following IAM policys to be able to list and associate Elastic IPs. This can probably be narrowed down a bit. It allows EC2 read-only (from the IAM wizard), `ec2:AssociateAddress` and `ec2:DisassociateAddress` permissions:
 
     {
+      "Version": "2012-10-17",
       "Statement": [
         {
           "Effect": "Allow",
           "Action": [
             "ec2:AssociateAddress",
-            "ec2:Describe*"
+            "ec2:Describe*",
+            "ec2:DisassociateAddress"
           ],
           "Resource": "*"
         }

--- a/aws_ec2_assign_elastic_ip/command_line_options.py
+++ b/aws_ec2_assign_elastic_ip/command_line_options.py
@@ -47,6 +47,12 @@ PARSER.add_argument(
         '- 58.0.0.0/8\n'
         '- 123.213.0.0/16,58.0.0.0/8,195.234.023.0\n'
         '- 195.234.234.23,195.234.234.24\n'))
+PARSER.add_argument(
+    '--replace',
+    action='store_true',
+    help=(
+        'If the instance is alredy assigned an IP not in\nvalid-ips then '
+        'replace it'))
 ARGS = PARSER.parse_args()
 
 if ARGS.version:


### PR DESCRIPTION
I have a cron that runs the following two commands:

```
aws-ec2-assign-elastic-ip --valid-ips vip-ip
aws-ec2-assign-elastic-ip --valid-ips lots,of,other,ips
```

The idea is that `vip-ip` should always be associated with an instance. This works when groups scale up but not when groups scale down. Thus I created the `--replace` option:

```
aws-ec2-assign-elastic-ip --valid-ips vip-ip --replace
aws-ec2-assign-elastic-ip --valid-ips lots,of,other,ips
```

Now if `vip-ip` is available it will disassociate any existing Elastic IP before associating `vip-ip`.
