### PR TITLE
Exlude IPs that have an ENI attached

### DIFF
--- a/aws_ec2_assign_elastic_ip/__init__.py
+++ b/aws_ec2_assign_elastic_ip/__init__.py
@@ -117,6 +117,12 @@ def _get_unassociated_address():
                 address.public_ip, address.instance_id))
             continue
 
+        #Check if the address is attached to an ENI
+        if address.network_interface_id:
+            logger.debug('{0} is already attached to {1}'.format(
+                address.public_ip, address.network_interface_id))
+            continue
+
         # Check if the address is in the valid IP's list
         if _is_valid(address.public_ip):
             logger.debug('{0} is unassociated and OK for us to take'.format(


### PR DESCRIPTION
The AWS API will return an error when you try to attach an EIP to an instance if the EIP is already attached to an ENI. Since AWS will not allow you to attach the EIP, then the EIP should be exluded from the list of avaliable IPs.
