### PR TITLE
--invalid-ips fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,17 @@ and AWS instance profiles.
                             - 58.0.0.0/8
                             - 123.213.0.0/16,58.0.0.0/8,195.234.023.0
                             - 195.234.234.23,195.234.234.24
+      --invalid-ips INVALID_IPS
+                            A comma separated list of Elastic IP ranges that 
+                            should NOT be used for assigning an ip.
+                            You can use CIDR expressions to select ranges.
+                            Valid examples:
+                            - 58.0.0.0/8
+                            - 123.213.0.0/16,58.0.0.0/8,195.234.023.0
+                            - 195.234.234.23,195.234.234.24
 
-The `--valid-ips` option require the public IPs in a comma separated sequence.
+
+The `--valid-ips` and `--invalid-ips` options require the public IPs in a comma separated sequence.
 E.g. `56.123.56.123,56.123.56.124,56.123.56.125`.
 
 Supported platforms

--- a/aws_ec2_assign_elastic_ip/__init__.py
+++ b/aws_ec2_assign_elastic_ip/__init__.py
@@ -189,7 +189,9 @@ def _is_valid(address):
     :returns: bool -- True if association is OK
     """
     if _is_ip_in_range(address, args.valid_ips):
-        if not _is_ip_in_range(address, args.invalid_ips):
+        if args.invalid_ips and _is_ip_in_range(address, args.invalid_ips):
+            return False
+        else:
             return True
 
     return False

--- a/aws_ec2_assign_elastic_ip/__init__.py
+++ b/aws_ec2_assign_elastic_ip/__init__.py
@@ -168,7 +168,7 @@ def _is_ip_in_range(address, ips):
         try:
             for ip in IPNetwork(conf_ip):
                 if str(ip) == str(address):
-                    return expected_state
+                    return True
 
         except AddrFormatError as err:
             logger.error('Invalid valid IP configured: {0}'.format(err))
@@ -178,7 +178,7 @@ def _is_ip_in_range(address, ips):
             logger.error('Invalid valid IP configured: {0}'.format(err))
             pass
 
-    return not expected_state
+    return False
 
 
 def _is_valid(address):


### PR DESCRIPTION
This PR fixes the 2 issues mentioned in #22 :
- Not specifying optional `--invalid-ips` causes no address to be assigned
- The following error:

```
2017-08-28 07:17:17,253 - aws-ec2-assign-eip - INFO - Connected to AWS EC2 in eu-west-1
Traceback (most recent call last):
  File "/usr/local/bin/aws-ec2-assign-elastic-ip", line 31, in <module>
    aws_ec2_assign_elastic_ip.main()
  File "/usr/local/lib/python2.7/dist-packages/aws_ec2_assign_elastic_ip/__init__.py", line 60, in main
    address = _get_unassociated_address()
  File "/usr/local/lib/python2.7/dist-packages/aws_ec2_assign_elastic_ip/__init__.py", line 127, in _get_unassociated_address
    if _is_valid(address.public_ip):
  File "/usr/local/lib/python2.7/dist-packages/aws_ec2_assign_elastic_ip/__init__.py", line 191, in _is_valid
    if _is_ip_in_range(address, args.valid_ips):
  File "/usr/local/lib/python2.7/dist-packages/aws_ec2_assign_elastic_ip/__init__.py", line 171, in _is_ip_in_range
    return expected_state
NameError: global name 'expected_state' is not defined
```