### PR TITLE
Update README.md with more restrictive IAM policy recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,7 @@ We currently support Python 2.6, 2.7 and 3.X
 Required IAM permissions
 ------------------------
 
-**Community contribution much appreciated on this!**
-
-We have been using the following IAM policys to be able to list and associate
-Elastic IPs. This can probably be narrowed down abit. It allows EC2 read-only
-(from the IAM wizard) and `ec2:AssociateAddress` permissions:
+We have been using the following IAM policies to be able to list and associate Elastic IPs. It allows EC2 `ec2:DescribeAddresses` and `ec2:AssociateAddress` permissions:
 
     {
       "Statement": [
@@ -92,7 +88,7 @@ Elastic IPs. This can probably be narrowed down abit. It allows EC2 read-only
           "Effect": "Allow",
           "Action": [
             "ec2:AssociateAddress",
-            "ec2:Describe*"
+            "ec2:DescribeAddresses"
           ],
           "Resource": "*"
         }


### PR DESCRIPTION
Updated the README.md to suggest a more restrictive IAM policy for
the EC2 IAM role. It seems only `ec2:DescribeAddresses` is needed
to get the current EC2 addresses and `ec2:AssociateAddress` is then needed
to assign one. Works fine when running the script directly on the EC2
instance with the EC2 instance role (i.e. without providing AWS
credentials explicitly)

If I'm not missing out on some edge case, then I think that's about it.
i guess ideally you would limit the `Resource` section to only the EC2 instance(s) that are using the IAM role to assign EIPs.