### PR TITLE
Allow filtering EIPs by AWS tag (New --tag parameter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ credential config options](http://boto.readthedocs.org/en/latest/boto_config_tut
 and AWS instance profiles.
 
     usage: aws-ec2-assign-elastic-ip [-h] [--version] [--region REGION]
-                                     [--access-key ACCESS_KEY]
-                                     [--secret-key SECRET_KEY] [--dry-run]
-                                     [--valid-ips VALID_IPS]
+                                 [--access-key ACCESS_KEY]
+                                 [--secret-key SECRET_KEY] [--dry-run]
+                                 [--valid-ips VALID_IPS]
+                                 [--invalid-ips INVALID_IPS]
+                                 [--tag [KEY=VALUE]]
 
     Assign EC2 Elastic IP to the current instance
 
@@ -63,7 +65,10 @@ and AWS instance profiles.
                             - 58.0.0.0/8
                             - 123.213.0.0/16,58.0.0.0/8,195.234.023.0
                             - 195.234.234.23,195.234.234.24
-
+      --tag [KEY=VALUE]     A case-sensitive tag (key=value pair) that valid Elastic IPs should have
+                            Valid examples:
+                            - Name=my-eip
+                            - Group=prod
 
 The `--valid-ips` and `--invalid-ips` options require the public IPs in a comma separated sequence.
 E.g. `56.123.56.123,56.123.56.124,56.123.56.125`.

--- a/aws_ec2_assign_elastic_ip/command_line_options.py
+++ b/aws_ec2_assign_elastic_ip/command_line_options.py
@@ -56,6 +56,15 @@ PARSER.add_argument(
         '- 58.0.0.0/8\n'
         '- 123.213.0.0/16,58.0.0.0/8,195.234.023.0\n'
         '- 195.234.234.23,195.234.234.24\n'))
+PARSER.add_argument(
+    '--tag',
+    metavar="KEY=VALUE",
+    nargs='?',
+    help=(
+        'A case-sensitive tag (key=value pair) that valid Elastic IPs should have\n'
+        'Valid examples:\n'
+        '- Name=my-eip\n'
+        '- Group=prod\n'))
 ARGS = PARSER.parse_args()
 
 if ARGS.version:


### PR DESCRIPTION
This PR, I believe, fixes: #31

### Summary:

Simple feature addition, as I was facing the same issue as described in #31.
Basically I was having a similar issue, where it would be of advantage to simply assign EIPs from a pool of EIPs that have a specific AWS tag (for example `Group=prod-eips`) instead of specifiying the IPs directly, which would require in my case EC2 launch configuration / CloudFormation template updates every time I would add or remove new EIPs.


### Usage:

The tag approach works pretty well in conjunction with auto-scaling groups. 
For example execute the script during the start-up of the EC2 instance via `UserData` or `cfn-init` helper scripts, like so:

```bash
pip install aws-ec2-assign-elastic-ip
aws-ec2-assign-elastic-ip --tag Group=prod-eips >> /var/log/aws-ec2-assign-elastic-ip.log
```

This then allows me to manage the allocated EIPs on AWS by adding or removing a tag with the key `Group` and the value `prod-eips`. Thus when I have the need to scale up my EC2 instances, I simply make sure I have enough EIPs with the correct tag available and then perform the scaling operation without updating the EC2 launch configuration.

If I want I can narrow down the eligible EIPs by still providing `--valid-ips` and `--invalid-ips` in addition to `--tag` as before.


@sebdah Let me know what you think. I'm not the greatest Python dev, so feel free to refactor it, but I think this could be useful for others as well (like #31  - even though it's coming one and half years too late for him, I suppose) :D 