### PR TITLE
fixes for python 3.11+

### DIFF
--- a/aws_ec2_assign_elastic_ip/command_line_options.py
+++ b/aws_ec2_assign_elastic_ip/command_line_options.py
@@ -2,9 +2,9 @@
 import argparse
 import sys
 try:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import SafeConfigParser as ConfigParser
 except ImportError:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
 from argparse import RawTextHelpFormatter
 
 if sys.platform in ['win32', 'cygwin']:
@@ -12,7 +12,7 @@ if sys.platform in ['win32', 'cygwin']:
 else:
     import os.path as ospath
 
-SETTINGS = SafeConfigParser()
+SETTINGS = ConfigParser()
 SETTINGS.read('{0}/settings.conf'.format(
     ospath.dirname(ospath.realpath(__file__))))
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@
 import os
 from setuptools import setup
 try:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import SafeConfigParser as ConfigParser
 except ImportError:
     from configparser import ConfigParser
 
-settings = SafeConfigParser()
+settings = ConfigParser()
 settings.read(os.path.realpath('aws_ec2_assign_elastic_ip/settings.conf'))
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 try:
     from ConfigParser import SafeConfigParser
 except ImportError:
-    from configparser import SafeConfigParser
+    from configparser import ConfigParser
 
 settings = SafeConfigParser()
 settings.read(os.path.realpath('aws_ec2_assign_elastic_ip/settings.conf'))


### PR DESCRIPTION
configparser has changed in recent versions of python, this redoes the imports so it will work 